### PR TITLE
unable to rename master to main for ietf db

### DIFF
--- a/ietfdb/Makefile
+++ b/ietfdb/Makefile
@@ -39,7 +39,7 @@ CVS_HOST = ietfdb.cvs.sourceforge.net
 #CVS_HOST = cvs.savannah.gnu.org
 CVS_MODULE = ietfdb
 #REMOTE_URL = cvs://$(CVS_HOST)/ietfdb\#$(CVS_MODULE)
-READ_OPTIONS = --branchify=trunk:attic/*:branch/*/*:personal/*/*:sprint/*/*:tags/*:tags/dev/*:*
+READ_OPTIONS = --branchify=trunk:attic/*:branch/*:branch/*/*:personal/*:personal/*/*:sprint/*:sprint/*/*:tags/*:tags/dev/*:*
 DUMPFILTER = cat
 VERBOSITY = "set progress"
 REPOSURGEON = reposurgeon


### PR DESCRIPTION
Fixes the issue of not able to rename the `master` branch to `main` in ietfdb

Resolves #22 